### PR TITLE
`exportcert` command: Export only if total hours contributed is positive and non-zero

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -370,6 +370,11 @@ Format: `exportcert VOLUNTEER_INDEX`
 * `VOLUNTEER INDEX` **must be a positive integer** 1, 2, 3, ...
 * If the index given exceeds the number of volunteers in the displayed volunteer list, the message 'The volunteer index provided is invalid.' will be shown.
 
+[NOTE]
+====
+A certificate will be exported only if *the volunteer has event records* and *the records have a positive, non-zero hour value*.
+====
+
 Example(s):
 
 * `exportcert 2` +

--- a/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
@@ -99,7 +99,7 @@ public class ExportCertCommand extends Command {
         Volunteer selectedVolunteer = lastShownList.get(index.getZeroBased());
 
         // Return CommandException if volunteer has no records
-        if (!hasEventRecords(model, selectedVolunteer)) {
+        if (!hasNonZeroEventRecords(model, selectedVolunteer)) {
             logger.info("Volunteer has no records.");
             throw new CommandException(MESSAGE_VOLUNTEER_NO_RECORD);
         }
@@ -121,7 +121,7 @@ public class ExportCertCommand extends Command {
      * @param volunteer who's presence of event {@code records} is to be checked
      * @return true if {@code volunteer} has {@code records}, and false otherwise
      */
-    private boolean hasEventRecords(Model model, Volunteer volunteer) {
+    private boolean hasNonZeroEventRecords(Model model, Volunteer volunteer) {
         VolunteerId volunteerId = volunteer.getVolunteerId();
 
         // Attempt to retrieve a list of the volunteer's records with non-zero hour value

--- a/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
@@ -26,6 +26,7 @@ import seedu.address.model.event.EventContainsEventIdPredicate;
 import seedu.address.model.event.EventId;
 import seedu.address.model.record.Hour;
 import seedu.address.model.record.Record;
+import seedu.address.model.record.RecordContainsNonZeroHourPredicate;
 import seedu.address.model.record.RecordContainsVolunteerIdPredicate;
 import seedu.address.model.volunteer.Name;
 import seedu.address.model.volunteer.Volunteer;
@@ -50,7 +51,8 @@ public class ExportCertCommand extends Command {
             + File.separator;
     public static final String PDF_ALT_SAVE_PATH = System.getProperty("user.home") + File.separator + "Desktop"
             + File.separator;
-    public static final String MESSAGE_VOLUNTEER_NO_RECORD = "Selected volunteer has no stored event records";
+    public static final String MESSAGE_VOLUNTEER_NO_RECORD = "Selected volunteer has no valid event records. "
+            + "Try adding some records or updating current records to set a positive non-zero hour value.";
 
     private static final java.util.logging.Logger logger = LogsCenter.getLogger(ExportCertCommand.class);
 
@@ -114,23 +116,24 @@ public class ExportCertCommand extends Command {
     }
 
     /**
-     * Checks if a {@code volunteer} has any event {@code record}s.
-     * @param model from which the {@code volunteer}'s {@code record}s will be retrieved, if present
-     * @param volunteer who's presence of event {@code record}s is to be checked
-     * @return true if {@code volunteer} has {@code record}s, and false otherwise
+     * Checks if a {@code volunteer} has any event {@code records}.
+     * @param model from which the {@code volunteer}'s {@code records} will be retrieved, if present
+     * @param volunteer who's presence of event {@code records} is to be checked
+     * @return true if {@code volunteer} has {@code records}, and false otherwise
      */
     private boolean hasEventRecords(Model model, Volunteer volunteer) {
         VolunteerId volunteerId = volunteer.getVolunteerId();
 
-        // Attempt to retrieve a list of the volunteer's records
+        // Attempt to retrieve a list of the volunteer's records with non-zero hour value
         List<Record> eventRecords = model.getFilteredRecordList()
-                .filtered(new RecordContainsVolunteerIdPredicate(volunteerId));
+                .filtered(new RecordContainsVolunteerIdPredicate(volunteerId))
+                .filtered(new RecordContainsNonZeroHourPredicate());
 
         return !eventRecords.isEmpty();
     }
 
     /**
-     * Creates and exports a PDF document containing a {@code volunteer}'s data
+     * Creates and exports a PDF document containing a {@code volunteer's} data
      * @param model from which the volunteer's event records will be accessed
      * @param volunteer who's data is to be input into the PDF document
      */

--- a/src/main/java/seedu/address/model/record/RecordContainsNonZeroHourPredicate.java
+++ b/src/main/java/seedu/address/model/record/RecordContainsNonZeroHourPredicate.java
@@ -1,0 +1,19 @@
+package seedu.address.model.record;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Record}'s {@code hour} is more than 0.
+ */
+public class RecordContainsNonZeroHourPredicate implements Predicate<Record> {
+    @Override
+    public boolean test(Record record) {
+        return Integer.parseInt(record.getHour().value) > 0;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RecordContainsNonZeroHourPredicate); // instanceof handles nulls
+    }
+}


### PR DESCRIPTION
Previously,
- Records with 0 hour values would still be included in the exported certificate. 
- Volunteers with all records having 0 hour values (thus no hours contributed at all) would still have their certificates exported. 

This is meaningless and doesn't achieve the intended purpose of the certificate (verification and formal record provision).

Thus, the following change was made:
- ExportCertCommand now goes through an additional layer of filtering through records to surface only the ones with a non-zero, positive hour value. Thus the above two instances are accordingly managed.

RecordContainsNonZeroHourPredicate has been created for this additional layer of filtering.