### PR TITLE
ExportCertCommand.java: Replace 'ID' with 'NRIC' in cert

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCertCommand.java
@@ -183,7 +183,7 @@ public class ExportCertCommand extends Command {
         contStream.showText(volunteerNameLine);
         contStream.newLine();
 
-        String volunteerIdLine = "Volunteer ID: " + volunteerId;
+        String volunteerIdLine = "Volunteer NRIC: " + volunteerId;
         contStream.showText(volunteerIdLine);
         contStream.newLine();
 


### PR DESCRIPTION
Simple update to exported certificate to display 'Volunteer NRIC' instead of 'Volunteer ID'